### PR TITLE
Update footer.twig

### DIFF
--- a/website/template/footer.twig
+++ b/website/template/footer.twig
@@ -1,7 +1,7 @@
 <section class="mt-24 py-12 bg-gray-800 text-gray-400 text-center text-sm font-light">
     <div class="container mx-auto px-4">
         <p>
-            &copy; 2022 Matthieu Napoli -
+            &copy; 2019-{{ 'now'|date('Y') }} Matthieu Napoli -
             <a href="https://github.com/brefphp/bref" class="text-blue-400">GitHub</a> -
             <a href="https://twitter.com/brefphp" class="text-blue-400">Twitter</a>
         </p>


### PR DESCRIPTION
use now as copyright year

<!--
According to https://www.copyrightlaws.com/copyright-symbol-notice-year/#:~:text=What%20About%20Blogs%20and%20Websites
copyright in the website should include year range, the first part should be year of first publication and the second part - the year of the latest modification
You can check amazon or ebay, they all use similar approach
-->
